### PR TITLE
Propagate the read status to the getEvent calls

### DIFF
--- a/Adafruit_LSM6DS.h
+++ b/Adafruit_LSM6DS.h
@@ -208,7 +208,7 @@ protected:
       gyroZ;         ///< Last reading's gyro Z axis in rad/s
   uint8_t chipID(void);
   uint8_t status(void);
-  virtual void _read(void);
+  virtual bool _read(void);
   virtual bool _init(int32_t sensor_id);
 
   uint16_t _sensorid_accel, ///< ID number for accelerometer

--- a/Adafruit_LSM6DSO32.cpp
+++ b/Adafruit_LSM6DSO32.cpp
@@ -57,13 +57,15 @@ bool Adafruit_LSM6DSO32::_init(int32_t sensor_id) {
  */
 /**************************************************************************/
 // works for now, should refactor
-void Adafruit_LSM6DSO32::_read(void) {
+bool Adafruit_LSM6DSO32::_read(void) {
   // get raw readings
   Adafruit_BusIO_Register data_reg = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LSM6DS_OUT_TEMP_L, 14);
 
   uint8_t buffer[14];
-  data_reg.read(buffer, 14);
+  if (!data_reg.read(buffer, 14)){
+    return false;
+  }
 
   rawTemp = buffer[1] << 8 | buffer[0];
   temperature = (rawTemp / 256.0) + 25.0;
@@ -108,6 +110,8 @@ void Adafruit_LSM6DSO32::_read(void) {
   accX = rawAccX * accel_scale * SENSORS_GRAVITY_STANDARD / 1000;
   accY = rawAccY * accel_scale * SENSORS_GRAVITY_STANDARD / 1000;
   accZ = rawAccZ * accel_scale * SENSORS_GRAVITY_STANDARD / 1000;
+
+  return true;
 }
 
 /**************************************************************************/

--- a/Adafruit_LSM6DSO32.h
+++ b/Adafruit_LSM6DSO32.h
@@ -40,7 +40,7 @@ public:
 
   lsm6dso32_accel_range_t getAccelRange(void);
   void setAccelRange(lsm6dso32_accel_range_t new_range);
-  void _read(void);
+  bool _read(void);
 
 private:
   bool _init(int32_t sensor_id);


### PR DESCRIPTION
The aim of this pull request is to implement the propagation of the read status through the getEvent calls, as is discussed in #26 . This allows users to check if the value provided by a getEvents is valid or is invalid, and to avoid feeding corrupted data further the pipes.

Test: this has been tested on a Sparkfun Artemis MCU based board against the Adafruit ISM330DHCX + LIS3MDL FeatherWing - High Precision 9-DoF IMU, PRODUCT ID: 4569. All compiling, no issues. I do not have more breakouts to test this myself.

If you have any comments please let me know :) .